### PR TITLE
docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: required
+
+language: erlang
+
+otp_release:
+  - 18.2.1
+
+services:
+- docker
+
+before_install:
+- docker build -t build_ubuntu https://raw.githubusercontent.com/systemd/erlang-sd_notify/master/docker/ubuntu/Dockerfile
+- docker images
+
+script:
+- docker run -v $TRAVIS_BUILD_DIR:/sd/ build_ubuntu /bin/sh -c "cd /sd/; make all"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Build from source `RPM`
  
 Download the binary
 -
-https://github.com/systemd/erlang-sd_notify/releases/tag/
+https://github.com/systemd/erlang-sd_notify/releases
 
 Install and Test
 -

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -12,7 +12,6 @@ RUN  yum install -y  \
 
 
 
-RUN mkdir /build && cd /build
 
 RUN wget https://www.rabbitmq.com/releases/erlang/erlang-18.3-1.el7.centos.x86_64.rpm
 

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu
+
+RUN apt-get -y update 
+
+RUN  apt-get install -y  \
+  gcc \
+  make \
+  git  \
+  wget \
+  erlang=1:18.3-dfsg-1ubuntu3 \
+  build-essential \
+	devscripts \
+	fakeroot \
+    debhelper \
+    erlang-dev \
+    libsystemd-dev\
+    erlang-eunit \
+    rebar
+
+
+
+

--- a/src/sd_notify.erl
+++ b/src/sd_notify.erl
@@ -57,7 +57,6 @@ sd_notify(_, _) ->
 sd_pid_notify(_, _, _) ->
 	?nif_stub.
 
-
 sd_notifyf(UnsetEnv, Format, Data) ->
 	sd_notify(UnsetEnv, lists:flatten(io_lib:format(Format, Data))).
 
@@ -71,7 +70,7 @@ sd_pid_notifyf(Pid, UnsetEnv, Format, Data) ->
 -ifdef(TEST).
 
 sd_notify_test() ->
-	?assertEqual(ok, ok).
+	?assertEqual(ok, ok). 
 
 sd_notifyf_test() ->
 	?assertEqual(ok, ok).


### PR DESCRIPTION
Fixes https://github.com/systemd/erlang-sd_notify/issues/9
1. Added docker image for build on ubuntu
2. Compile using Docker over Travis

In this PR it uses ubuntu image to build, later we can add also the Centos (or others) docker image(s)
