### PR TITLE
Add spec for Centos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,6 @@ dialyzer:
 
 deb:
 	cd packaging/deb && $(MAKE) TOPDIR=$(PWD) deb
+
+rpm: 
+	cd packaging/centos && $(MAKE) TOPDIR=$(PWD) rpm

--- a/README.md
+++ b/README.md
@@ -11,11 +11,7 @@ Installation
 On Fedora/CentOS
     
 ```bash
-    extract the tar.gz
-    mkdir -p /usr/lib64/erlang/lib/sd_notify-{version}/priv/
-    mkdir -p /usr/lib64/erlang/lib/sd_notify-{version}/ebin/
-    cp priv/* /usr/lib64/erlang/lib/sd_notify-{version}/priv/
-    cp ebin/* /usr/lib64/erlang/lib/sd_notify-{version}/ebin/
+    rpm -i erlang-sd_notify-{version}-1.el7.centos.x86_64.rpm
 ```    
 
 On Debian/Ubuntu
@@ -38,7 +34,7 @@ Centos
 
 ```bash
     docker build -t build_centos_{version} docker/centos_{version}/
-    docker run -v {sd_notify_dir}:/home/sd/ build_centos_{version} /bin/sh -c "cd /home/sd/; make all"
+    docker run -v {sd_notify_dir}:/home/sd/ build_centos_{version} /bin/sh -c "cd /home/sd/; make rpm"
 ```
 
 Example

--- a/packaging/centos/Makefile
+++ b/packaging/centos/Makefile
@@ -1,0 +1,36 @@
+FINAL_OUTPUT_DIR=FINAL_RPMS
+
+
+
+VERSION=0.12
+
+# Directory names
+RPM_BUILD_DIR=rpm-build
+PKG_NAME=erlang-sd_notify
+RPM_SOURCE_DIR=$(PKG_NAME)-$(VERSION)
+
+TOP_DIR=$(shell pwd)
+
+TARBALL_DIR=$(TOPDIR)
+SOURCE_TGZ=$(PKG_NAME)-$(VERSION).tar.gz
+TARGET_DIR=$(TARGET_TOP)/usr/lib/erlang/lib/sd_notify-$(VERSION)
+
+
+DEFINES=--define '_topdir $(TOP_DIR)' --define '_tmppath $(TOP_DIR)/tmp' --define '_sysconfdir /etc' --define '_localstatedir /var'
+
+rpm:	clean erlang-sd_notify
+
+prepare:
+	mkdir -p BUILD SOURCES SPECS SRPMS RPMS tmp dist $(TARBALL_DIR)
+	tar czf $(TARBALL_DIR)/$(SOURCE_TGZ)  -C $(TOPDIR)  src/ c_src/ rebar.config LICENSE
+	cp $(TOPDIR)/$(SOURCE_TGZ) SOURCES
+	rm $(TOPDIR)/$(SOURCE_TGZ)
+	cp erlang-sd_notify.spec SPECS
+
+erlang-sd_notify: prepare
+	mkdir -p $(FINAL_OUTPUT_DIR)
+	rpmbuild -vvv -bb --nodeps SPECS/erlang-sd_notify.spec $(DEFINES)
+	find RPMS -name "*.rpm" -exec sh -c 'mv {} `echo {} | sed 's#^RPMS\/noarch#$(FINAL_OUTPUT_DIR)#'`' ';'
+
+clean:
+	rm -rf BUILDROOT BUILD SOURCES SPECS SRPMS RPMS tmp $(FINAL_OUTPUT_DIR) dist

--- a/packaging/centos/erlang-sd_notify.spec
+++ b/packaging/centos/erlang-sd_notify.spec
@@ -21,7 +21,7 @@ BuildRequires:	systemd-devel
 %description
 %{summary}.
 
-%prep -c .
+%prep 
 %setup  -c .
 
 %build

--- a/packaging/centos/erlang-sd_notify.spec
+++ b/packaging/centos/erlang-sd_notify.spec
@@ -46,7 +46,25 @@ install -m 755 -p priv/%{realname}_drv.so $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%
 
 
 %changelog
-* Sat Oct 29 2016 Igor Gnatenko <g.santomaggio@gmail.com> - 0.12
-- nitial build for 0.12
+* Sat Oct 29 2016 Gabriele Santomaggio <g.santomaggio@gmail.com> - 0.12
+- build for 0.12
+
+* Wed Jun 17 2015 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.1-6
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_23_Mass_Rebuild
+
+* Tue Nov 04 2014 Peter Lemenkov <lemenkov@gmail.com> - 0.1-5
+- Rebuild with Erlang 17.3.3
+
+* Thu Oct  2 2014 John Eckersberg <eck@redhat.com> - 0.1-4
+- Explicitly link shared library with libsystemd (#1148604)
+
+* Thu Aug 28 2014 Peter Lemenkov <lemenkov@gmail.com> - 0.1-3
+- Rebuild with Erlang 17.2.1
+
+* Sat Aug 16 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org>
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_21_22_Mass_Rebuild
+
+* Tue Jun 03 2014 Peter Lemenkov <lemenkov@gmail.com> - 0.1-1
+- initial build
 
 

--- a/packaging/centos/erlang-sd_notify.spec
+++ b/packaging/centos/erlang-sd_notify.spec
@@ -1,0 +1,52 @@
+%global realname sd_notify
+%global upstream systemd
+%global upstream_version 0.12
+
+
+
+Name:		erlang-%{realname}
+Version:	%{upstream_version}
+Release:	1%{?dist}
+Summary:	Erlang interface to systemd notify subsystem
+License:	MIT
+URL:		https://github.com/%{upstream}/%{realname}
+VCS:		scm:git:https://github.com/%{upstream}/%{realname}.git
+Source0:	https://github.com/%{upstream}/%{realname}/archive/%{version}/erlang-%{realname}-%{version}.tar.gz
+Source1:	erlang-sd_notify-rebar.config
+BuildRequires:	erlang-rebar
+BuildRequires:	systemd-devel
+%{?__erlang_nif_version:Requires: %{__erlang_nif_version}}
+
+
+%description
+%{summary}.
+
+%prep -c .
+%setup  -c .
+
+%build
+rebar compile
+
+
+%install
+mkdir -p $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%{realname}-%{version}/{ebin,priv}
+install -m 644 -p ebin/%{realname}.app $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%{realname}-%{version}/ebin
+install -m 644 -p ebin/%{realname}.beam $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%{realname}-%{version}/ebin
+install -m 755 -p priv/%{realname}_drv.so $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%{realname}-%{version}/priv
+
+
+%files
+%doc LICENSE
+%dir %{_libdir}/erlang/lib/%{realname}-%{version}/
+%dir %{_libdir}/erlang/lib/%{realname}-%{version}/ebin/
+%dir %{_libdir}/erlang/lib/%{realname}-%{version}/priv/
+%{_libdir}/erlang/lib/%{realname}-%{version}/ebin/%{realname}.app
+%{_libdir}/erlang/lib/%{realname}-%{version}/ebin/%{realname}.beam
+%{_libdir}/erlang/lib/%{realname}-%{version}/priv/%{realname}_drv.so
+
+
+%changelog
+* Sat Oct 29 2016 Igor Gnatenko <g.santomaggio@gmail.com> - 0.12
+- nitial build for 0.12
+
+

--- a/src/sd_notify.app.src
+++ b/src/sd_notify.app.src
@@ -1,7 +1,7 @@
 {application, sd_notify,
  [
   {description, "Erlang sd_notify NIF"},
-  {vsn, git},
+  {vsn, "git"},
   {registered, []},
   {applications, [
                   kernel,


### PR DESCRIPTION
@lemenkov this PR implements https://github.com/systemd/erlang-sd_notify/issues/7

To test it:

```
docker run -it -v  {sd_notify_dir}:/home/sd/ build_centos_19 /bin/sh -c "cd /home/sd/; make rpm"
```

output in:

```
packaging/centos/RPMS/x86_64/erlang-sd_notify-0.12-1.el7.centos.x86_64.rpm
```

Here the file [erlang-sd_notify-0.12-1.el7.centos.x86_64.rpm.zip](https://github.com/systemd/erlang-sd_notify/files/560050/erlang-sd_notify-0.12-1.el7.centos.x86_64.rpm.zip)
