### PR TITLE
Add stub for NIF upgrade

### DIFF
--- a/c_src/sd_notify.c
+++ b/c_src/sd_notify.c
@@ -24,6 +24,11 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "erl_nif.h"
 #include <systemd/sd-daemon.h>
 
+static int upgrade(ErlNifEnv* env, void** priv, void** old_priv, ERL_NIF_TERM load_info)
+{
+	return 0;
+}
+
 static ERL_NIF_TERM sd_pid_notify_with_fds_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
 	ERL_NIF_TERM head, tail;
@@ -63,4 +68,9 @@ static ErlNifFunc nif_funcs[] =
 
 };
 
-ERL_NIF_INIT(sd_notify, nif_funcs, NULL, NULL, NULL, NULL);
+// Initialize this NIF library.
+//
+// Args: (MODULE, ErlNifFunc funcs[], load, reload, upgrade, unload)
+// Docs: http://erlang.org/doc/man/erl_nif.html#ERL_NIF_INIT
+
+ERL_NIF_INIT(sd_notify, nif_funcs, NULL, NULL, &upgrade, NULL);


### PR DESCRIPTION
Suppress error during reloads. This is mostly harmless (I'm not aware of any issues related to this), but very scary and misleadingly looking for those who uses Erlang just for running some popular Erlang apps. So let's fix it.

Before:

```
lemenkov ~/work/erlang-sd_notify (git::master): erl -pa ebin
Erlang/OTP 19 [erts-8.1.1] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V8.1.1  (abort with ^G)
1> code:load_file(sd_notify).
{module,sd_notify}
2> code:load_file(sd_notify).
{error,on_load_failure}
3> 
=WARNING REPORT==== 14-Dec-2016::13:53:42 ===
The on_load function for module sd_notify returned {error,
                                                    {upgrade,
                                                     "Upgrade not supported by this NIF library."}}

3>
```

After:

```
lemenkov ~/work/erlang-sd_notify (git::suppress_error_during_restarts): erl -pa ebin
Erlang/OTP 19 [erts-8.1.1] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V8.1.1  (abort with ^G)
1> code:load_file(sd_notify).
{module,sd_notify}
2> code:load_file(sd_notify).
{module,sd_notify}
3>
```

Signed-off-by: Peter Lemenkov <lemenkov@redhat.com>