### PR TITLE
Introduce eunit tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ services:
 - docker
 
 before_install:
+- kerl list installations
 - docker build -t build_ubuntu https://raw.githubusercontent.com/systemd/erlang-sd_notify/master/docker/ubuntu_18_3/Dockerfile
 - docker images
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,13 @@ sudo: required
 language: erlang
 
 otp_release:
-  - 18.2.1
+- 18.0
+- 18.1
+- 18.2
+- 18.2.1
+- 18.3
+- 19.0
+- 19.1
 
 services:
 - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
 - docker images
 
 script:
-- docker run -v $TRAVIS_BUILD_DIR:/home/sd/ build_ubuntu /bin/sh -c "cd /home/sd/; make all"
+- docker run -v $TRAVIS_BUILD_DIR:/home/sd/ build_ubuntu /bin/sh -c "cd /home/sd/; make all; make test"

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ all: compile
 compile:
 	$(REBAR) compile $(REBAR_FLAGS)
 
+check: test
 test: compile
 	$(REBAR) eunit $(REBAR_FLAGS)
 

--- a/c_src/sd_notify.c
+++ b/c_src/sd_notify.c
@@ -45,7 +45,7 @@ static ERL_NIF_TERM sd_pid_notify_with_fds_nif(ErlNifEnv* env, int argc, const E
 	enif_get_string(env, argv[2], state, length, ERL_NIF_LATIN1);
 
 	enif_get_list_length(env, argv[3], &length);
-	int* fds = (int*)enif_alloc(++length * sizeof(int));
+	int* fds = (int*)enif_alloc(length * sizeof(int));
 	ERL_NIF_TERM list = argv[3];
 	int i = 0;
 	while(enif_get_list_cell(env, list, &head, &tail)) {

--- a/c_src/sd_notify.c
+++ b/c_src/sd_notify.c
@@ -61,7 +61,6 @@ static ERL_NIF_TERM sd_pid_notify_with_fds_nif(ErlNifEnv* env, int argc, const E
 	return enif_make_int(env, result);
 }
 
-
 static ErlNifFunc nif_funcs[] =
 {
 	{"sd_pid_notify_with_fds", 4, sd_pid_notify_with_fds_nif},

--- a/src/sd_notify.erl
+++ b/src/sd_notify.erl
@@ -36,10 +36,6 @@
 nif_stub_error(Line) ->
 	erlang:nif_error({nif_not_loaded,module,?MODULE,line,Line}).
 
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
--endif.
-
 init() ->
 	PrivDir = case code:priv_dir(?MODULE) of
 			  {error, bad_name} ->
@@ -65,16 +61,3 @@ sd_pid_notifyf(Pid, UnsetEnv, Format, Data) ->
 
 sd_pid_notify_with_fds(_, _, _, _) ->
 	?nif_stub.
-
-%% ===================================================================
-%% EUnit tests
-%% ===================================================================
--ifdef(TEST).
-
-sd_notify_test() ->
-	?assertEqual(ok, ok). 
-
-sd_notifyf_test() ->
-	?assertEqual(ok, ok).
-
--endif.

--- a/test/sd_notify_test.erl
+++ b/test/sd_notify_test.erl
@@ -1,0 +1,27 @@
+-module(sd_notify_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+sd_notify_test_() ->
+	{ok, CWD} = file:get_cwd(),
+	FakeNotifyUnixSockName = CWD ++ "/fake-notify-udp-sock-" ++ integer_to_list(erlang:phash2(make_ref())),
+	TestMessage = integer_to_list(erlang:phash2(make_ref())),
+	{ok, FakeNotifyUnixSock} = gen_udp:open(0, [{ifaddr, {local, FakeNotifyUnixSockName}}, {active, false}, list]),
+	os:putenv("NOTIFY_SOCKET", FakeNotifyUnixSockName),
+
+	{setup,
+		fun() -> ok end,
+		fun(_) -> ok = gen_udp:close(FakeNotifyUnixSock), ok = file:delete(FakeNotifyUnixSockName)  end,
+		[
+			{
+				"Try sending message",
+				fun() ->
+					sd_notify:sd_pid_notify_with_fds(0, 0, TestMessage, [1, 2, 3]),
+					{ok, {_Address, _Port, Packet}} = gen_udp:recv(FakeNotifyUnixSock, length(TestMessage), 1000),
+					?assertEqual(TestMessage, Packet)
+				end
+			}
+
+		]
+
+	}.

--- a/test/sd_notify_test.erl
+++ b/test/sd_notify_test.erl
@@ -2,7 +2,11 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+
 sd_notify_test_() ->
+	sd_notify_test_local(erlang:system_info(otp_release)).
+
+sd_notify_test_local("19") ->
 	{ok, CWD} = file:get_cwd(),
 	FakeNotifyUnixSockName = CWD ++ "/fake-notify-udp-sock-" ++ integer_to_list(erlang:phash2(make_ref())),
 	TestMessage = integer_to_list(erlang:phash2(make_ref())),
@@ -24,4 +28,6 @@ sd_notify_test_() ->
 
 		]
 
-	}.
+	};
+sd_notify_test_local(_) ->
+	[].


### PR DESCRIPTION
This PR introduces eunit tests (1 test so far). Also it fixes another one typo, and few cosmetic / whitespace removal cleanups.

Unfortunately this test requires Erlang 19 as it uses local sockets. So it's not possible to test using pre-19 Erlang versions. That's why I didn't enable tests in Travis-CI yet (running tests only if Erlang 19 is available is beyond my Travis-CI kung-fu knowledge).