### PR TITLE
Ci tests centos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,14 @@
 sudo: required
 
-language: erlang
-
-otp_release:
-- 18.0
-- 18.1
-- 18.2
-- 18.2.1
-- 18.3
-- 19.0
-- 19.1
-
 services:
 - docker
 
 before_install:
-- kerl list installations
-- docker build -t build_ubuntu https://raw.githubusercontent.com/systemd/erlang-sd_notify/master/docker/ubuntu_18_3/Dockerfile
-- docker images
+- docker build -t build_ubuntu_18_3 docker/ubuntu_18_3/
+- docker build -t build_centos_18_3 docker/centos_18_3/
+- docker build -t build_centos_19 docker/centos_19/
 
 script:
-- docker run -v $TRAVIS_BUILD_DIR:/home/sd/ build_ubuntu /bin/sh -c "cd /home/sd/; make all; make test"
+- docker run -v $TRAVIS_BUILD_DIR:/home/sd/ build_ubuntu_18_3 /bin/sh -c "cd /home/sd/; make all; make test"
+- docker run -v $TRAVIS_BUILD_DIR:/home/sd/ build_centos_18_3 /bin/sh -c "cd /home/sd/; make all; make test"
+- docker run -v $TRAVIS_BUILD_DIR:/home/sd/ build_centos_19 /bin/sh -c "cd /home/sd/; make all; make test"

--- a/test/sd_notify_test.erl
+++ b/test/sd_notify_test.erl
@@ -9,7 +9,6 @@ sd_notify_test_() ->
 sd_notify_test_local("19") ->
 	{ok, CWD} = file:get_cwd(),
 	FakeNotifyUnixSockName = CWD ++ "/fake-notify-udp-sock-" ++ integer_to_list(erlang:phash2(make_ref())),
-	TestMessage = integer_to_list(erlang:phash2(make_ref())),
 	{ok, FakeNotifyUnixSock} = gen_udp:open(0, [{ifaddr, {local, FakeNotifyUnixSockName}}, {active, false}, list]),
 	os:putenv("NOTIFY_SOCKET", FakeNotifyUnixSockName),
 
@@ -20,6 +19,7 @@ sd_notify_test_local("19") ->
 			{
 				"Try sending message",
 				fun() ->
+					TestMessage = integer_to_list(erlang:phash2(make_ref())),
 					sd_notify:sd_pid_notify_with_fds(0, 0, TestMessage, [1, 2, 3]),
 					{ok, {_Address, _Port, Packet}} = gen_udp:recv(FakeNotifyUnixSock, length(TestMessage), 1000),
 					?assertEqual(TestMessage, Packet)

--- a/test/sd_notify_test.erl
+++ b/test/sd_notify_test.erl
@@ -20,7 +20,7 @@ sd_notify_test_local("19") ->
 				"Try sending message",
 				fun() ->
 					TestMessage = integer_to_list(erlang:phash2(make_ref())),
-					sd_notify:sd_pid_notify_with_fds(0, 0, TestMessage, [1, 2, 3]),
+					1 = sd_notify:sd_pid_notify_with_fds(0, 0, TestMessage, []),
 					{ok, {_Address, _Port, Packet}} = gen_udp:recv(FakeNotifyUnixSock, length(TestMessage), 1000),
 					?assertEqual(TestMessage, Packet)
 				end


### PR DESCRIPTION
I've fixed test for CentOS 7 finally. The problem was the list of FDs (1,2,3]) which apparently was rejected by the libsystemd 219 available in this distro (or by some library below, likely a Glibc).

This closes bug #24.